### PR TITLE
Move mime package to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3151,8 +3151,7 @@
     "mime": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
-      "dev": true
+      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
     },
     "mime-db": {
       "version": "1.40.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "express-session": "^1.17.0",
     "gpf-js": "^1.0.0",
     "lodash": "^4.17.19",
-    "mime": "^2.4.4",
     "minimist": ">=1.2.3",
     "mocha": "^7.1.2",
     "mock-require": "^3.0.3",
@@ -62,7 +61,9 @@
     "standard": "^14.3.1",
     "start-server-and-test": "^1.10.6"
   },
-  "dependencies": {},
+  "dependencies": {
+    "mime": "^2.4.4"
+  },
   "standard": {
     "globals": [
       "process",


### PR DESCRIPTION
- to mitigate mime.getType() is not a function, and consuming package
need of having mime in dependencies